### PR TITLE
Add configurable cache engine

### DIFF
--- a/api.php
+++ b/api.php
@@ -85,6 +85,6 @@ $data = $cache->fetch('api', function () use(
   curl_close($ch);
 
   return $data;
-}, 30);
+});
 
 returnJson($data);

--- a/api.php
+++ b/api.php
@@ -9,82 +9,82 @@ $cache = Cache::factory();
 setlocale(LC_ALL, 'en_US');
 
 // get cached response
-$data = $cache->fetch('api', function () use(
+$data = $cache->fetch('api', function () use (
   &$nanoNodeRPCIP, &$nanoNodeRPCPort, &$nanoNodeAccount, &$blockExplorer,
   &$nanoNodeName, &$nanoNumDecimalPlaces, &$uptimerobotApiKey
 ) {
-  // get curl handle
-  $ch = curl_init();
+    // get curl handle
+    $ch = curl_init();
 
-  if (!$ch) {
-      myError('Could not initialize curl!');
-  }
+    if (!$ch) {
+        myError('Could not initialize curl!');
+    }
 
-  // we have a valid curl handle here
-  // set some curl options
-  curl_setopt($ch, CURLOPT_URL, 'http://'.$nanoNodeRPCIP.':'.$nanoNodeRPCPort);
-  curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
-  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    // we have a valid curl handle here
+    // set some curl options
+    curl_setopt($ch, CURLOPT_URL, 'http://'.$nanoNodeRPCIP.':'.$nanoNodeRPCPort);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-  $data = new stdClass();
-  $data->nanoNodeAccount = $nanoNodeAccount;
-  $data->nanoNodeAccountShort = truncateAddress($data->nanoNodeAccount);
-  $data->nanoNodeAccountUrl = getAccountUrl($data->nanoNodeAccount, $blockExplorer);
+    $data = new stdClass();
+    $data->nanoNodeAccount = $nanoNodeAccount;
+    $data->nanoNodeAccountShort = truncateAddress($data->nanoNodeAccount);
+    $data->nanoNodeAccountUrl = getAccountUrl($data->nanoNodeAccount, $blockExplorer);
 
-  // -- Get Version String from nano_node
-  $data->version = getVersionFormatted($ch);
-  $data->newNodeVersionAvailable = isNewNodeVersionAvailable($data->version);
+    // -- Get Version String from nano_node
+    $data->version = getVersionFormatted($ch);
+    $data->newNodeVersionAvailable = isNewNodeVersionAvailable($data->version);
 
-  // -- Get get current block from nano_node
-  $rpcBlockCount = getBlockCount($ch);
-  $data->currentBlock = (int) $rpcBlockCount->{'count'};
-  $data->uncheckedBlocks = (int) $rpcBlockCount->{'unchecked'};
-  $data->blockSync = getSyncStatus($data->currentBlock);
+    // -- Get get current block from nano_node
+    $rpcBlockCount = getBlockCount($ch);
+    $data->currentBlock = (int) $rpcBlockCount->{'count'};
+    $data->uncheckedBlocks = (int) $rpcBlockCount->{'unchecked'};
+    $data->blockSync = getSyncStatus($data->currentBlock);
 
-  // -- Get number of peers from nano_node
-  $rpcPeers = getPeers($ch);
-  $peers = (array) $rpcPeers->{'peers'};
-  $data->numPeers = count($peers);
+    // -- Get number of peers from nano_node
+    $rpcPeers = getPeers($ch);
+    $peers = (array) $rpcPeers->{'peers'};
+    $data->numPeers = count($peers);
 
-  // -- Get node account balance from nano_node
-  $rpcNodeAccountBalance = getAccountBalance($ch, $nanoNodeAccount);
-  $data->accBalanceMnano = rawToMnano($rpcNodeAccountBalance->{'balance'}, $nanoNumDecimalPlaces);
-  $data->accBalanceRaw = (int) $rpcNodeAccountBalance->{'balance'};
-  $data->accPendingMnano = rawToMnano($rpcNodeAccountBalance->{'pending'}, $nanoNumDecimalPlaces);
-  $data->accPendingRaw = (int) $rpcNodeAccountBalance->{'pending'};
+    // -- Get node account balance from nano_node
+    $rpcNodeAccountBalance = getAccountBalance($ch, $nanoNodeAccount);
+    $data->accBalanceMnano = rawToMnano($rpcNodeAccountBalance->{'balance'}, $nanoNumDecimalPlaces);
+    $data->accBalanceRaw = (int) $rpcNodeAccountBalance->{'balance'};
+    $data->accPendingMnano = rawToMnano($rpcNodeAccountBalance->{'pending'}, $nanoNumDecimalPlaces);
+    $data->accPendingRaw = (int) $rpcNodeAccountBalance->{'pending'};
 
-  // -- Get representative info for current node from nano_node
-  $rpcNodeRepInfo = getRepresentativeInfo($ch, $nanoNodeAccount);
-  $data->repAccount = $rpcNodeRepInfo->{'representative'} ?: '';
-  $data->repAccountShort = truncateAddress($data->repAccount);
-  $data->repAccountUrl = getAccountUrl($data->repAccount, $blockExplorer);
+    // -- Get representative info for current node from nano_node
+    $rpcNodeRepInfo = getRepresentativeInfo($ch, $nanoNodeAccount);
+    $data->repAccount = $rpcNodeRepInfo->{'representative'} ?: '';
+    $data->repAccountShort = truncateAddress($data->repAccount);
+    $data->repAccountUrl = getAccountUrl($data->repAccount, $blockExplorer);
 
-  // get the account weight
-  $rpcNodeAccountWeight = getAccountWeight($ch, $nanoNodeAccount);
-  $data->votingWeight = rawToMnano($rpcNodeAccountWeight->{'weight'}, $nanoNumDecimalPlaces);
+    // get the account weight
+    $rpcNodeAccountWeight = getAccountWeight($ch, $nanoNodeAccount);
+    $data->votingWeight = rawToMnano($rpcNodeAccountWeight->{'weight'}, $nanoNumDecimalPlaces);
 
-  // -- System uptime & memory info --
-  $data->systemLoad = getSystemLoadAvg();
-  $systemUptime = getSystemUptime();
-  $systemUptimeStr = $systemUptime['days'].' days, '.$systemUptime['hours'].' hrs, '.$systemUptime['mins'].' mins';
-  $data->systemUptime = $systemUptimeStr;
-  $data->usedMem = getSystemUsedMem();
-  $data->totalMem = getSystemTotalMem();
-  //$data->uname = getUname();
-  $data->nanoNodeName = $nanoNodeName;
+    // -- System uptime & memory info --
+    $data->systemLoad = getSystemLoadAvg();
+    $systemUptime = getSystemUptime();
+    $systemUptimeStr = $systemUptime['days'].' days, '.$systemUptime['hours'].' hrs, '.$systemUptime['mins'].' mins';
+    $data->systemUptime = $systemUptimeStr;
+    $data->usedMem = getSystemUsedMem();
+    $data->totalMem = getSystemTotalMem();
+    //$data->uname = getUname();
+    $data->nanoNodeName = $nanoNodeName;
 
-  // get the node uptime (if we have a api key)
-  if ($uptimerobotApiKey) {
-      $data->nodeUptime = getNodeUptime($uptimerobotApiKey);
-  }
+    // get the node uptime (if we have a api key)
+    if ($uptimerobotApiKey) {
+        $data->nodeUptime = getNodeUptime($uptimerobotApiKey);
+    }
 
-  // get info from Nano Node Ninja
-  $data->nodeNinja = getNodeNinja($nanoNodeAccount);
+    // get info from Nano Node Ninja
+    $data->nodeNinja = getNodeNinja($nanoNodeAccount);
 
-  // close curl handle
-  curl_close($ch);
+    // close curl handle
+    curl_close($ch);
 
-  return $data;
+    return $data;
 });
 
 returnJson($data);

--- a/modules/Cache.php
+++ b/modules/Cache.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once __DIR__.'/cache/FileCache.php';
+require_once __DIR__.'/cache/NullCache.php';
+
+abstract class Cache {
+  public static function factory() {
+    global $cache;
+    switch ($cache["engine"]) {
+      case 'files': return new FileCache($cache['options']);
+      default: return new NullCache();
+    }
+  }
+
+  abstract public function read($key);
+  abstract public function write($key, $data, $options = []);
+
+  public function fetch($key, $callback, $options = []) {
+    $data = $this->read($key);
+    if (is_null($data)) {
+      $data = $callback();
+      $this->write($key, $data, $options);
+    }
+
+    return $data;
+  }
+}

--- a/modules/Cache.php
+++ b/modules/Cache.php
@@ -17,13 +17,13 @@ abstract class Cache {
   }
 
   abstract public function read($key);
-  abstract public function write($key, $data, $options = []);
+  abstract public function write($key, $data);
 
-  public function fetch($key, $callback, $options = []) {
+  public function fetch($key, $callback) {
     $data = $this->read($key);
     if (is_null($data)) {
       $data = $callback();
-      $this->write($key, $data, $options);
+      $this->write($key, $data);
     }
 
     return $data;

--- a/modules/Cache.php
+++ b/modules/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__.'/cache/ApcCache.php';
+require_once __DIR__.'/cache/ApcuCache.php';
 require_once __DIR__.'/cache/FileCache.php';
 require_once __DIR__.'/cache/NullCache.php';
 
@@ -7,6 +9,8 @@ abstract class Cache {
   public static function factory() {
     global $cache;
     switch ($cache["engine"]) {
+      case 'apc': return new ApcCache($cache['options']);
+      case 'apcu': return new ApcuCache($cache['options']);
       case 'files': return new FileCache($cache['options']);
       default: return new NullCache();
     }

--- a/modules/cache/ApcCache.php
+++ b/modules/cache/ApcCache.php
@@ -13,7 +13,7 @@ class ApcCache extends Cache {
     return NULL;
   }
 
-  public function write($key, $data, $options = []) {
+  public function write($key, $data) {
     return apc_store($key, $data, $this->ttl);
   }
 }

--- a/modules/cache/ApcCache.php
+++ b/modules/cache/ApcCache.php
@@ -1,0 +1,19 @@
+<?php
+
+class ApcCache extends Cache {
+  private $ttl;
+
+  public function __construct(array $options = array()) {
+    $this->ttl = array_key_exists('ttl', $options) ? $options['ttl'] : 30;
+  }
+
+  public function read($key) {
+    $data = apc_fetch($key, $success);
+    if ($success) return $data;
+    return NULL;
+  }
+
+  public function write($key, $data, $options = []) {
+    return apc_store($key, $data, $this->ttl);
+  }
+}

--- a/modules/cache/ApcuCache.php
+++ b/modules/cache/ApcuCache.php
@@ -1,0 +1,19 @@
+<?php
+
+class ApcuCache extends Cache {
+  private $ttl;
+
+  public function __construct(array $options = array()) {
+    $this->ttl = array_key_exists('ttl', $options) ? $options['ttl'] : 30;
+  }
+
+  public function read($key) {
+    $data = apcu_fetch($key, $success);
+    if ($success) return $data;
+    return NULL;
+  }
+
+  public function write($key, $data, $options = []) {
+    return apcu_store($key, $data, $this->ttl);
+  }
+}

--- a/modules/cache/ApcuCache.php
+++ b/modules/cache/ApcuCache.php
@@ -13,7 +13,7 @@ class ApcuCache extends Cache {
     return NULL;
   }
 
-  public function write($key, $data, $options = []) {
+  public function write($key, $data) {
     return apcu_store($key, $data, $this->ttl);
   }
 }

--- a/modules/cache/FileCache.php
+++ b/modules/cache/FileCache.php
@@ -23,13 +23,18 @@ class FileCache extends Cache
     private $cache_dir = '/tmp/cache';
 
     /**
+     * The cache time in seconds.
+     */
+    private $ttl = 30;
+
+    /**
      * Creates a FileCache object
      *
      * @param array $options
      */
     public function __construct(array $options = array())
     {
-        $available_options = array('cache_dir');
+        $available_options = array('cache_dir', 'ttl');
         foreach ($available_options as $name) {
             if (isset($options[$name])) {
                 $this->$name = $options[$name];
@@ -81,11 +86,10 @@ class FileCache extends Cache
      *
      * @param string $id
      * @param mixed  $data
-     * @param int    $lifetime
      *
      * @return bool
      */
-    public function write($id, $data, $lifetime = 3600)
+    public function write($id, $data)
     {
         $dir = $this->getDirectory($id);
         if (!is_dir($dir)) {
@@ -94,7 +98,7 @@ class FileCache extends Cache
             }
         }
         $file_name  = $this->getFileName($id);
-        $lifetime   = time() + $lifetime;
+        $lifetime   = time() + $this->ttl;
         $serialized = serialize($data);
         $result     = file_put_contents($file_name, $lifetime . PHP_EOL . $serialized);
         if ($result === false) {

--- a/modules/cache/FileCache.php
+++ b/modules/cache/FileCache.php
@@ -13,9 +13,9 @@
  * @author  Taiji Inoue <inudog@gmail.com>
  */
 
-class FileCache
+class FileCache extends Cache
 {
-    
+
     /**
      * The root cache directory.
      * @var string
@@ -42,12 +42,12 @@ class FileCache
      *
      * @param string $id
      */
-    public function get($id)
+    public function read($id)
     {
         $file_name = $this->getFileName($id);
 
         if (!is_file($file_name) || !is_readable($file_name)) {
-            return false;
+            return NULL;
         }
 
         $lines    = file($file_name);
@@ -56,7 +56,7 @@ class FileCache
 
         if ($lifetime !== 0 && $lifetime < time()) {
             @unlink($file_name);
-            return false;
+            return NULL;
         }
         $serialized = join('', $lines);
         $data       = unserialize($serialized);
@@ -85,7 +85,7 @@ class FileCache
      *
      * @return bool
      */
-    public function save($id, $data, $lifetime = 3600)
+    public function write($id, $data, $lifetime = 3600)
     {
         $dir = $this->getDirectory($id);
         if (!is_dir($dir)) {

--- a/modules/cache/NullCache.php
+++ b/modules/cache/NullCache.php
@@ -5,7 +5,7 @@ class NullCache extends Cache {
     return NULL;
   }
 
-  public function write($key, $data, $options = []) {
+  public function write($key, $data) {
     return NULL;
   }
 }

--- a/modules/cache/NullCache.php
+++ b/modules/cache/NullCache.php
@@ -1,0 +1,11 @@
+<?php
+
+class NullCache extends Cache {
+  public function read($key) {
+    return NULL;
+  }
+
+  public function write($key, $data, $options = []) {
+    return NULL;
+  }
+}

--- a/modules/config.sample.php
+++ b/modules/config.sample.php
@@ -4,7 +4,7 @@
 // Please copy this file as config.php
 
 // To edit a config uncomment the line, otherwise
-// defaults will be used for each variable. 
+// defaults will be used for each variable.
 
 // ----------- General Variables -----------
 
@@ -32,6 +32,17 @@
 // choice of Nano block explorer ('nanode', 'ninja', 'nanoexplorer', 'nano', 'nanowatch')
 // $blockExplorer = 'nanode';
 
+// Cache engine, which allows for caching of RPC calls to reduce load on your Nano node.
+// Possible options are:
+//    - NULL (no caching)
+//    - "files" (caches to file; kind of slow)
+//    - "apc" (APC cache; requires extension; fast)
+//    - "apcu" (APCu cache; requires extension; fast)
+// $cache = [
+//   "engine" => "files",
+//   "options" => []
+// ];
+
 // ----------- Nano Node Variables -----------
 
 // ip address for RPC (default: [::1])
@@ -40,13 +51,13 @@
 // ip address for RPC (default: 7076)
 // $nanoNodeRPCPort = '7076';
 
-// account of this node 
-// $nanoNodeAccount = 'xrb_1f56swb9qtpy3yoxiscq9799nerek153w43yjc9atoaeg3e91cc9zfr89ehj'; 
+// account of this node
+// $nanoNodeAccount = 'xrb_1f56swb9qtpy3yoxiscq9799nerek153w43yjc9atoaeg3e91cc9zfr89ehj';
 
 // donation account for maintaining this node
 // $nanoDonationAccount = 'xrb_1f56swb9qtpy3yoxiscq9799nerek153w43yjc9atoaeg3e91cc9zfr89ehj';
 
-// number of decimal places to display Nano balances, i.e. 
+// number of decimal places to display Nano balances, i.e.
 // $nanoNumDecimalPlaces = 2;
 
 // ----------- Social -----------

--- a/modules/defaults.php
+++ b/modules/defaults.php
@@ -30,6 +30,11 @@ $cmcStatsticker = FALSE;
 // choice of Nano block explorer ('nanode', 'nanoexplorer', 'nano')
 $blockExplorer = 'nanode';
 
+$cache = [
+  "engine" => "files",
+  "options" => []
+];
+
 // ----------- Nano Node Variables -----------
 
 // ip address for RPC (default: 127.0.0.1)
@@ -38,13 +43,13 @@ $nanoNodeRPCIP   = '[::1]';
 // ip address for RPC (default: 7076)
 $nanoNodeRPCPort = '7076';
 
-// account of this node 
-$nanoNodeAccount = ''; 
+// account of this node
+$nanoNodeAccount = '';
 
 // donation account for maintaining this node
 $nanoDonationAccount = $nanoNodeAccount;
 
-// number of decimal places to display Nano balances, i.e. 
+// number of decimal places to display Nano balances, i.e.
 $nanoNumDecimalPlaces = 6;
 
 // ----------- Monitoring -----------

--- a/modules/defaults.php
+++ b/modules/defaults.php
@@ -30,6 +30,14 @@ $cmcStatsticker = FALSE;
 // choice of Nano block explorer ('nanode', 'nanoexplorer', 'nano')
 $blockExplorer = 'nanode';
 
+// Cache engine, which allows for caching of RPC calls to reduce load on your Nano node.
+// Possible options are:
+//    - NULL (no caching)
+//    - "files" (caches to file; kind of slow)
+//    - "apc" (APC cache; requires extension; fast)
+//      - Options: 'ttl' => cache time in seconds
+//    - "apcu" (APCu cache; requires extension; fast)
+//      - Options: 'ttl' => cache time in seconds
 $cache = [
   "engine" => "files",
   "options" => []

--- a/modules/functions.php
+++ b/modules/functions.php
@@ -30,8 +30,9 @@ function getSystemLoadAvg()
 }
 
 // get system memory info
-function getSystemMemInfo() 
-{       
+function getSystemMemInfo()
+{
+    if (!file_exists("/proc/meminfo")) return NULL;
     $data = explode("\n", file_get_contents("/proc/meminfo"));
     $meminfo = array();
     foreach ($data as $line) {
@@ -57,6 +58,7 @@ function getSystemUsedMem()
 // get system uptime array with secs, mins, hours and days
 function getSystemUptime()
 {
+    if (!file_exists('/proc/uptime')) return NULL;
     $str   = file_get_contents('/proc/uptime');
     $num   = intval($str);
     $array = array();
@@ -108,7 +110,7 @@ function getLatestReleaseVersion()
   $err = curl_error($curl);
 
   curl_close($curl);
-  
+
   if ($err) {
     return "API error";
   }
@@ -120,8 +122,8 @@ function getLatestReleaseVersion()
   if (property_exists($response, "tag_name"))
   {
       $tagString = $response->tag_name;
-  
-    // search for version name x.x.x 
+
+    // search for version name x.x.x
     if (0 != preg_match('/(\d+\.?)+$/', $tagString, $versionString))
     {
         return $versionString[0];
@@ -131,7 +133,7 @@ function getLatestReleaseVersion()
   return "";
 }
 
-// get a string with information about the 
+// get a string with information about the
 // current version and possible updates
 function getVersionInformation()
 {
@@ -175,7 +177,7 @@ function getLatestNodeReleaseVersion()
   $err = curl_error($curl);
 
   curl_close($curl);
-  
+
   if ($err) {
     return "API error";
   }
@@ -192,7 +194,7 @@ function getLatestNodeReleaseVersion()
   return '';
 }
 
-// get a string with information about the 
+// get a string with information about the
 // current version and possible updates
 function isNewNodeVersionAvailable($currentVersion)
 {
@@ -217,7 +219,7 @@ function getUname()
 function getNodeUptime($apiKey, $uptimeRatio = 30)
 {
   $curl = curl_init();
-  
+
   curl_setopt_array($curl, array(
     CURLOPT_URL => "https://api.uptimerobot.com/v2/getMonitors",
     CURLOPT_RETURNTRANSFER => true,
@@ -232,13 +234,13 @@ function getNodeUptime($apiKey, $uptimeRatio = 30)
       "content-type: application/x-www-form-urlencoded"
     ),
   ));
-  
+
   $response = curl_exec($curl);
   $err = curl_error($curl);
   $errCode = -1;
-  
+
   curl_close($curl);
-  
+
   if ($err) {
     return $errCode;
   }
@@ -260,7 +262,7 @@ function getNodeUptime($apiKey, $uptimeRatio = 30)
 function getNodeNinja($account)
 {
   $curl = curl_init();
-  
+
   curl_setopt_array($curl, array(
     CURLOPT_URL => "https://nanonode.ninja/api/accounts/$account",
     CURLOPT_RETURNTRANSFER => true,
@@ -269,12 +271,12 @@ function getNodeNinja($account)
     CURLOPT_TIMEOUT => 5,
     CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1
   ));
-  
+
   $response = curl_exec($curl);
   $err = curl_error($curl);
-  
+
   curl_close($curl);
-  
+
   if ($err) {
     return "API error";
   }
@@ -285,11 +287,11 @@ function getNodeNinja($account)
   if (isset($response->error)) {
     return false;
   }
-  
+
   return $response;
 }
 
-// truncate long Nano addresses to display the first and 
+// truncate long Nano addresses to display the first and
 // last characaters with ellipsis in the center
 function truncateAddress($addr)
 {
@@ -322,7 +324,7 @@ function getAccountUrl($account, $blockExplorer)
 function getNodeNinjaBlockcount()
 {
   $curl = curl_init();
-  
+
   curl_setopt_array($curl, array(
     CURLOPT_URL => "https://nanonode.ninja/api/blockcount",
     CURLOPT_RETURNTRANSFER => true,
@@ -331,12 +333,12 @@ function getNodeNinjaBlockcount()
     CURLOPT_TIMEOUT => 5,
     CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1
   ));
-  
+
   $response = curl_exec($curl);
   $err = curl_error($curl);
-  
+
   curl_close($curl);
-  
+
   if ($err) {
     return "API error";
   }
@@ -347,7 +349,7 @@ function getNodeNinjaBlockcount()
   if (isset($response->error)) {
     return false;
   }
-  
+
   return $response->count;
 }
 

--- a/modules/functions_rpc.php
+++ b/modules/functions_rpc.php
@@ -45,7 +45,7 @@ function getVersionFormatted($ch){
 
 
 // get block count from nano_node
-function getBlockCount($ch) 
+function getBlockCount($ch)
 {
   // get block count
   $data = array("action" => "block_count");
@@ -55,7 +55,7 @@ function getBlockCount($ch)
 }
 
 // get number of peers
-function getPeers($ch) 
+function getPeers($ch)
 {
   // get peers
   $data = array("action" => "peers");
@@ -65,7 +65,7 @@ function getPeers($ch)
 }
 
 // get account balance for nano_node account
-function getAccountBalance($ch, $account) 
+function getAccountBalance($ch, $account)
 {
   // get account balance
   $data = array("action" => "account_balance", "account" => $account);
@@ -75,12 +75,12 @@ function getAccountBalance($ch, $account)
 }
 
 // get representative info for nano_node account
-function getRepresentativeInfo($ch, $account) 
+function getRepresentativeInfo($ch, $account)
 {
   // get account info
-  $data = array("action" => "account_info", 
-                "account" => $account, 
-                "representative" => "true", 
+  $data = array("action" => "account_info",
+                "account" => $account,
+                "representative" => "true",
                 "weight" => "true");
 
   // post curl
@@ -88,11 +88,11 @@ function getRepresentativeInfo($ch, $account)
 }
 
 // get account weight nano_node account
-function getAccountWeight($ch, $account) 
+function getAccountWeight($ch, $account)
 {
   // get account weight
   $data = array(
-    "action" => "account_weight", 
+    "action" => "account_weight",
     "account" => $account
   );
 

--- a/modules/includes.php
+++ b/modules/includes.php
@@ -3,7 +3,7 @@
 // checks if the config file got edited
 if(!file_exists(__DIR__ . '/config.php')) {
 	require_once(__DIR__ . '/functions.php');
-    myError('Please edit the config file first! Go to the <i>modules</i> folder, ' . 
+    myError('Please edit the config file first! Go to the <i>modules</i> folder, ' .
     	    ' execute <i>cp config.sample.php config.php</i> and modify <i>config.php</i> ' .
     	    ' according to your needs.');
 }
@@ -24,7 +24,7 @@ require_once(__DIR__ . '/functions_rpc.php');
 require_once(__DIR__ . '/functions.php');
 
 // load file caching lib
-require_once(__DIR__ . '/FileCache.php');
+require_once(__DIR__ . '/Cache.php');
 
 // check for curl package (needs functions)
 if (!phpCurlAvailable()) {


### PR DESCRIPTION
This PR adds a configurable and pluggable cache engine that lets you cache calls to the RPC in various ways. This PR implements:

* File cache (existed, pulled from develop branch)
* APC cache
* APCu cache

A future PR could add something like memcached or Redis as a caching option. I should note that I was unable to get APC to compile on my system, but APCu did, so I've only tested the files + APCu cache options. APC _should_ be identical, but I would appreciate it if someone else was able to test it.

This is intended to solve #37.