### PR TITLE
Disables Rocket Loader™ from Cloudflare

### DIFF
--- a/modules/cmc_widget.php
+++ b/modules/cmc_widget.php
@@ -8,4 +8,4 @@ data-marketcap="<?php echo bool2string($cmcMarketcap); ?>"
 data-volume="<?php echo bool2string($cmcVolume); ?>" 
 data-stats="<?php echo $cmcBaseCurrency; ?>" 
 data-statsticker="<?php echo bool2string($cmcStatsticker); ?>"></div>
-<script src="https://files.coinmarketcap.com/static/widget/currency.js" async></script>
+<script data-cfasync="false" src="https://files.coinmarketcap.com/static/widget/currency.js" async></script>


### PR DESCRIPTION
By default, Rocket Loader™ from Cloudflare is enabled and prevents the CMC widget from loading data