### PR TITLE
Fix link color in alert

### DIFF
--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -3,7 +3,7 @@
   <button type="button" class="close" data-dismiss="alert">&times;</button>
   <strong>Heads up!</strong> A new Nano Node version
   <strong>{{newNodeVersionAvailable}}</strong> is available.
-  <a href="https://github.com/nanocurrency/raiblocks/releases/latest" target="_blank">Download it here!</a>
+  <a class="alert-link" href="https://github.com/nanocurrency/raiblocks/releases/latest" target="_blank">Download it here!</a>
 </div>
 {{/if}}
 


### PR DESCRIPTION
Bootstrap [offers](https://getbootstrap.com/docs/3.3/components/#alerts-links) "alert-link" class for links inside alerts to be "proper" color. Without this class, link to new version is white text at yellow background and poor visible.