### PR TITLE
Support for block confirmation times

### DIFF
--- a/api.php
+++ b/api.php
@@ -67,7 +67,8 @@ $data = $cache->fetch($apiName, function () use (
     $peers = (array) $rpcPeers->{'peers'};
     $data->numPeers = count($peers);
 
-    // -- Get confirmation info from nano_node. Average time, blocks used, time span  and percentiles over last 5min or max 2048 blocks
+    // -- Get confirmation info from nano_node. Average time, blocks used, time span  and percentiles 
+    // -- over last X min (set by CONFIRMATION_TIME_LIMIT) or max 2048 blocks which is a node limitation
     //$timeStampBefore = microtime(true);
     $rpcConfHistory = getConfirmationHistory($ch);
     $confirmations = $rpcConfHistory->{'confirmations'}; // a list of last X confirmations {hash,duration,time,tally}

--- a/api.php
+++ b/api.php
@@ -67,6 +67,51 @@ $data = $cache->fetch($apiName, function () use (
     $peers = (array) $rpcPeers->{'peers'};
     $data->numPeers = count($peers);
 
+    // -- Get confirmation info from nano_node. Average time, blocks used, time span  and percentiles over last 5min or max 2048 blocks
+    //$timeStampBefore = microtime(true);
+    $rpcConfHistory = getConfirmationHistory($ch);
+    $confirmations = $rpcConfHistory->{'confirmations'}; // a list of last X confirmations {hash,duration,time,tally}
+    //$confAverage = $rpcConfHistory->{'confirmation_stats'}->{'average'}; // average time [ms] of all confirmations
+    //$confCount = $rpcConfHistory->{'confirmation_stats'}->{'count'}; // number of confirmations retrieved from the node
+
+    // remove data older than $timeLimit
+    usort($confirmations, "cmpByTime"); // sort array by time value [ms unix time]
+    $confCompact = array(); // new filtered array
+    $durationTotal = 0; // for average calc
+    $confAverage = 0; // average confirmation duration
+    $timeSpan = 0; // full time span of the data [ms]
+    foreach ($confirmations as $confirmation) {
+        // only keep data which is later than X ms from latest (highest) value
+        if ($confirmation->{'time'} >= $confirmations[0]->{'time'} - CONFIRMATION_TIME_LIMIT) {
+            array_push($confCompact, $confirmation); // add new data
+            $durationTotal += $confirmation->{'duration'};
+        }
+        else {
+            break; // stop iterating once we pass that limit to save time
+        }
+    }
+    $confCount = count($confCompact);
+
+    // calculate duration average and time span, avoid dividing by zero
+    if ($confCount > 0) {
+        $confAverage = round($durationTotal / $confCount);
+        $timeSpan = $confCompact[0]->{'time'} - $confCompact[$confCount-1]->{'time'}; // first minus last
+    }
+
+    // get percentiles directly from the filtered array
+    usort($confCompact, "cmpByDuration"); // sort array by duration value
+    $percentile50 = getConfirmationsDurationPercentile(50, $confCompact); // 50 percentile also called median
+    $percentile75 = getConfirmationsDurationPercentile(75, $confCompact);
+    $percentile90 = getConfirmationsDurationPercentile(90, $confCompact);
+    $percentile95 = getConfirmationsDurationPercentile(95, $confCompact);
+    $percentile99 = getConfirmationsDurationPercentile(99, $confCompact);
+
+    // combine an array with all confirmation info
+    $confSummary = array('count' => $confCount, 'timeSpan' => $timeSpan, 'average' => $confAverage, 'percentile50' => $percentile50,
+    'percentile75' => $percentile75, 'percentile90' => $percentile90, 'percentile95' => $percentile95, 'percentile99' => $percentile99);
+    $data->confirmationInfo = $confSummary;
+    //$data->apiProcTimeConf = round((microtime(true) - $timeStampBefore) * 1000);
+
     // -- Get node account balance from nano_node
     $rpcNodeAccountBalance = getAccountBalance($ch, $nanoNodeAccount);
     $data->accBalanceMnano = rawToCurrency($rpcNodeAccountBalance->{'balance'}, $currency);

--- a/api.php
+++ b/api.php
@@ -69,7 +69,7 @@ $data = $cache->fetch($apiName, function () use (
 
     // -- Get confirmation info from nano_node. Average time, blocks used, time span  and percentiles 
     // -- over last X min (set by CONFIRMATION_TIME_LIMIT) or max 2048 blocks which is a node limitation
-    //$timeStampBefore = microtime(true);
+    //$timeStampBefore = microtime(true); // measure execution time
     $rpcConfHistory = getConfirmationHistory($ch);
     $confirmations = $rpcConfHistory->{'confirmations'}; // a list of last X confirmations {hash,duration,time,tally}
     //$confAverage = $rpcConfHistory->{'confirmation_stats'}->{'average'}; // average time [ms] of all confirmations

--- a/api.php
+++ b/api.php
@@ -167,6 +167,9 @@ $data = $cache->fetch($apiName, function () use (
     // close curl handle
     curl_close($ch);
 
+    // calculate total script execution time
+    $data->apiProcTime = round((microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"]) * 1000);
+
     return $data;
 });
 

--- a/modules/constants.php
+++ b/modules/constants.php
@@ -29,3 +29,6 @@ define ('NINJA_TIMEOUT', 3);
 
 // curl timeout in seconds to connect to ninja (max delay is NINJA_TIMEOUT + NINJA_CONECTTIMEOUT)
 define ('NINJA_CONECTTIMEOUT', 2);
+
+// maximum allowed age of data to be part of the block confirmation time percentiles calculation (milliseconds)
+define ('CONFIRMATION_TIME_LIMIT', 600000);

--- a/modules/functions.php
+++ b/modules/functions.php
@@ -510,3 +510,29 @@ function currencySymbol($currency)
   }
 
 }
+
+// sort array by 'duration' sub value
+function cmpByDuration($a, $b) {
+  return $a->{'duration'} - $b->{'duration'};
+}
+
+// sort array by 'time' sub value (largest first)
+function cmpByTime($a, $b) {
+  return $b->{'time'} - $a->{'time'};
+}
+
+// get a percentile from a sorted json structure which contains sub element values with the name 'duration'
+// ex: get_percentile(75, $arr) to get the 75th percentile
+function getConfirmationsDurationPercentile($percentile, $array) {
+    if (empty($array)) {
+        return 0;
+    }
+    $index = ($percentile/100) * count($array);
+    if (floor($index) == $index) {
+         $result = ($array[$index-1]->{'duration'} + $array[$index]->{'duration'})/2;
+    }
+    else {
+        $result = $array[floor($index)]->{'duration'};
+    }
+    return $result;
+}

--- a/modules/functions_rpc.php
+++ b/modules/functions_rpc.php
@@ -102,3 +102,13 @@ function getStats($ch, $type = "counters")
   // post curl
   return postCurl($ch, $data);
 }
+
+// get confirmation history from nano_node
+function getConfirmationHistory($ch)
+{
+  // get confirmation history of latest 2048 elections
+  $data = array("action" => "confirmation_history");
+
+  // post curl
+  return postCurl($ch, $data);
+}


### PR DESCRIPTION
Using the RCP call "confirmation_history" to retrieve past confirmation durations.
Collect data and calculate average, 50th, 75th, 90th, 95th and 99th percentiles over last 10minutes or 2048 values max. Also output number of blocks used in the calculation and the total timespan in ms. During high TPS on the network, the timespan will be smaller and limited to 2048 tx.

**Added to api json output:**
`"confirmationInfo":{"count":110,"timeSpan":544570,"average":1872,"percentile50":1396,"percentile75":"2091","percentile90":3359,"percentile95":"4319","percentile99":"12247"}`

An example of how the data can be used is shown here in the Block Confirmation Times chart:
https://node.nanolinks.info/nano.html

The metrics could also be used by nanocrawler for example to track average of all monitored reps to get a measure of overall network performance.

The complete execution time, including RPC call for this addition was measured to 69ms out of 300ms total for the api.php script. Also added the total execution metric to the JSON output like so:
`"apiProcTime":278}`

That can help node owners to not set their cache interval too low if their node is slow.

The new json output is found here: https://monitor.nanolinks.info/api.php

If this is merged, I will also update https://github.com/Joohansson/NanoNodeGraphics to give this tool to everyone.