### PR TITLE
Reorganize monitor information to footer

### DIFF
--- a/modules/footer.php
+++ b/modules/footer.php
@@ -1,51 +1,49 @@
 <footer id="footer">
 
-  <p>
-   <?php
-    global $versionCache;
-    $versionCache = new FileCache(["ttl" => 10*60]); // cache for 10 minutes
-
-    // set an API name so multiple monitors don't mix
-    $apiName = "footer-$nanoNodeAccount";
-
-     // get cached response
-    $versionData = $versionCache->fetch($apiName, function () {
-        $versionData = new stdClass();
-        $versionData->latestVersion  = getLatestReleaseVersion();
-        return $versionData;
-    });
-    echo getVersionInformation($versionData->latestVersion);
-   ?>
-
-   <br>
-    Made by <a href="https://github.com/NanoTools" target="_blank" rel="noopener">Nano Tools</a>.
-   <br>
-    GitHub: <a href="<?php echo PROJECT_URL; ?>" target="_blank" rel="noopener">Source</a> | <a href="<?php echo PROJECT_URL . '/wiki'; ?>" target="_blank" rel="noopener">Wiki</a> | <a href="<?php echo PROJECT_URL . '/wiki/API-Description'; ?>" target="_blank" rel="noopener">API</a>
-  </p>
-
   <hr class=light>
 
-  <p class=truncate>
-   <small>
+  <small>
 
-<?php
-  // switch Nano / Banano rep accounts & explorer
-  $repAccount = NODEMON_REP_ACCOUNT;
-  $donAccount = NODEMON_DON_ACCOUNT;
-  $repExplorer = 'ninja';
+    <?php
+      // switch Nano / Banano rep accounts & explorer
+      $repAccount = NODEMON_REP_ACCOUNT;
+      $donAccount = NODEMON_DON_ACCOUNT;
+      $repExplorer = 'ninja';
 
-  if ($currency == "banano")
-  {
-    $repAccount = NODEMON_BAN_REP_ACCOUNT;
-    $donAccount = NODEMON_BAN_DON_ACCOUNT;
-    $repExplorer = 'banano';
-  }
-?>
+      if ($currency == "banano")
+      {
+        $repAccount = NODEMON_BAN_REP_ACCOUNT;
+        $donAccount = NODEMON_BAN_DON_ACCOUNT;
+        $repExplorer = 'banano';
+      }
+    ?>
 
-    Donations to <?php echo currencyName($currency); ?> Node Monitor: <a href="<?php echo getAccountUrl($donAccount, $blockExplorer); ?>" target="_blank" rel="noopener"><?php echo $donAccount; ?></a>
-   </small>
-   <button id="copyAccount" class="btn btn-sm btn-link btn-clipboard-light" data-clipboard-text="<?php echo $donAccount; ?>" title="Copy"><i class="fas fa-clipboard fa-lg"></i></button>
-  </p>
+    <ul>
+      <li>
+         <?php
+         global $versionCache;
+         $versionCache = new FileCache(["ttl" => 10*60]); // cache for 10 minutes
+
+         // set an API name so multiple monitors don't mix
+         $apiName = "footer-$nanoNodeAccount";
+
+         // get cached response
+         $versionData = $versionCache->fetch($apiName, function () {
+             $versionData = new stdClass();
+             $versionData->latestVersion  = getLatestReleaseVersion();
+             return $versionData;
+         });
+         echo getVersionInformation($versionData->latestVersion);
+         ?>
+      </li>
+      <li>Powered by <a href="<?php echo PROJECT_URL ?>">Nano Node Monitor</a></li>
+      <li>GitHub: <a href="<?php echo PROJECT_URL; ?>" target="_blank" rel="noopener">Source</a> | <a href="<?php echo PROJECT_URL . '/wiki'; ?>" target="_blank" rel="noopener">Wiki</a> | <a href="<?php echo PROJECT_URL . '/wiki/API-Description'; ?>" target="_blank" rel="noopener">API</a></li>
+      <li>
+        Donate: <a href="<?php echo getAccountUrl($donAccount, $blockExplorer); ?>" target="_blank" rel="noopener"><?php echo truncateAddress($donAccount); ?></a>
+      </li>
+      <li>Made by <a href="https://github.com/NanoTools" target="_blank" rel="noopener">Nano Tools</a></li>
+    </ul>
+  </small>
 </footer>
 
 </div><!-- /container -->

--- a/modules/functions.php
+++ b/modules/functions.php
@@ -321,7 +321,7 @@ function getNodeNinja($account)
 }
 
 // truncate long Nano addresses to display the first and
-// last characaters with ellipsis in the center
+// last characters with ellipsis in the center
 function truncateAddress($addr)
 {
   $totalNumChar = NANO_ADDR_NUM_CHAR;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -7,7 +7,7 @@
 .float-left-truncate
 {
     float: left;
-    margin-right: auto;  
+    margin-right: auto;
     text-align: left;
     overflow: hidden;
     white-space: nowrap;
@@ -19,7 +19,7 @@
 .float-right-truncate
 {
     float: right;
-    margin-left: auto;  
+    margin-left: auto;
     text-align: right;
     overflow: hidden;
     white-space: nowrap;
@@ -28,24 +28,32 @@
 }
 
 .myError
-{   
+{
     padding: 20px;
     background-color: #f44336; /* Red */
     color: white;
     margin-bottom: 30px;
 }
 
-.coinmarketcap-currency-widget div > span 
-{ 
-    color: white; 
-} 
+.coinmarketcap-currency-widget div > span
+{
+    color: white;
+}
 
 .coinmarketcap-currency-widget div > span:last-child
-{   
-    color: #7c7c7e !important; 
+{
+    color: #7c7c7e !important;
 }
 
 .coinmarketcap-currency-widget > div > div:nth-child(2) > div
 {
     color: #dddddd;
+}
+
+#footer ul
+{
+    text-align: right;
+    letter-spacing: 0.02em;
+    list-style: none;
+    padding-right: 10px;
 }


### PR DESCRIPTION
**Motivation**
This is an opinionated topic so it's hard to validate it's correctness. The previous design, although good, displays information about the tool (monitor) near information about the node making it feel cluttered and possibly confusing. 

This change moves that information to the footer to better separate the node information from the monitor information. 

It wasn't straight forward to incorporate the clipboard icon into the new design and I wasn't sure how useful it really is given that the use can simply click on the link and get a QR code and copy/paste functionality from the explorer. It can probably be reintroduced with a little more work if desired.

_Before:_
![image](https://user-images.githubusercontent.com/475559/60770932-31adcd80-a0a6-11e9-8244-647e7aaa8dd4.png)

_After:_
![image](https://user-images.githubusercontent.com/475559/60770956-75083c00-a0a6-11e9-91fb-44b7886590a3.png)
