### PR TITLE
Add store_vendor as Database backend for Node V21.0

### DIFF
--- a/api.php
+++ b/api.php
@@ -37,6 +37,7 @@ $data = $cache->fetch($apiName, function () use (
     $data->version = $version->{'node_vendor'};
     $data->store_version = (int) $version->{'store_version'} ?: 0;
     $data->protocol_version = (int) $version->{'protocol_version'} ?: 0;
+    $data->store_vendor = (string) $version->{'store_vendor'} ?: '';
 
     // Cache the github query for latest node version
     global $nodeVersionCache;

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -30,10 +30,12 @@
         <li class="list-group-item">
           <span class="float-left-truncate">Version</span>
           <span class="float-right-truncate">{{version}}</span>
+        {{#if store_vendor}} <!--Node V21-->
         <li class="list-group-item">
           <span class="float-left-truncate">Database</span>
           <span class="float-right-truncate">{{store_vendor}}</span>
         </li>
+        {{/if}}
         </li>
         <li class="list-group-item">
           <span class="float-left-truncate">Current Block</span>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -30,6 +30,10 @@
         <li class="list-group-item">
           <span class="float-left-truncate">Version</span>
           <span class="float-right-truncate">{{version}}</span>
+        <li class="list-group-item">
+          <span class="float-left-truncate">Database</span>
+          <span class="float-right-truncate">{{store_vendor}}</span>
+        </li>
         </li>
         <li class="list-group-item">
           <span class="float-left-truncate">Current Block</span>


### PR DESCRIPTION
Update to RPC [version](https://docs.nano.org/commands/rpc-protocol/#version). Saved as `$data->store_vendor` , with default empty string.

Also added to the main page, preview:
![image](https://user-images.githubusercontent.com/12448106/71123353-5ae89300-21da-11ea-911f-df657fe73802.png)