### PR TITLE
Improve details display

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -57,3 +57,17 @@
     list-style: none;
     padding-right: 10px;
 }
+
+/* overload css */
+.float-left-truncate {
+  width: 100%;
+  font-size: 80%;
+  margin-left: -1rem;
+  margin-top: -0.7rem;
+}
+
+.float-right-truncate {
+  width: 100%;
+  margin-right: -0.7rem;
+  margin-bottom: -0.4rem;
+}


### PR DESCRIPTION
Labels in details are smaller and positioned above values, so values can occupy full width.

![demo](https://user-images.githubusercontent.com/3540597/148610316-256fc80c-8fa8-4831-a421-2b36a7451320.png)
